### PR TITLE
adding group-by clause with simple aggregation functions

### DIFF
--- a/src/database.py
+++ b/src/database.py
@@ -291,6 +291,7 @@ class Database:
 
         select_clause = utils.get_select_clause(query_ast, relations_to_alias, alias)
         where_clause = utils.get_where_clause(query_ast, relations_to_alias, alias)
+        group_by_clause = utils.get_group_by_clause(query_ast, relations_to_alias, alias)
 
         limit = ""
         if "limit" in query_ast:
@@ -299,7 +300,7 @@ class Database:
         # print("\n\nRelations to aliases: ")
         # self.print_dict(relations_to_alias)
 
-        query = select_clause + " FROM " + subq + where_clause + limit
+        query = select_clause + " FROM " + subq + where_clause + group_by_clause + limit
 
         # print(query)
         self.counter = 0

--- a/src/database_utils.py
+++ b/src/database_utils.py
@@ -18,6 +18,9 @@ def get_select_clause(query_ast, relations_to_alias, alias):
     select_operator_map = {
         "min": "MIN",
         "max": "MAX",
+        "count": "COUNT",
+        "sum": "SUM",
+        "avg": "AVG"
     }  # to be filled with other possible values
 
     select_stmt = query_ast["select"]
@@ -183,3 +186,25 @@ def get_where_clause(query_ast, relations_to_alias, alias):
 
     else:
         return ""
+
+def get_group_by_clause(query_ast, relations_to_alias, alias):
+    if 'groupby' in query_ast:
+        group_ast = query_ast['groupby']
+        groupby = []
+
+        if not isinstance(group_ast, (list,)):
+            group_ast = [group_ast]
+
+        for v in group_ast:
+            val = v["value"]
+            val = get_alias(val, relations_to_alias, alias)
+            groupby.append(val)
+
+        groupby_clause = " \nGROUP BY \n"
+        for i in range(len(groupby) - 1):
+            groupby_clause += groupby[i] + ", "
+        groupby_clause += groupby[len(groupby) - 1]
+        return groupby_clause
+    else:
+        return ""
+


### PR DESCRIPTION
Simple aggregation functions should work in the SELECT clause such as SUM, COUNT, AVG, MIN, MAX
I tested on the following: 
1. queries with simple aggregation functions with group-by clauses -> seems to work fine
2. queries without group-by clauses -> seems to work fine
3. queries with more complicated expressions in the aggregation function i.e. SUM(l_extendedprice * (1 - l_discount)) -> does not work yet as the expression in the SUM() is not yet properly supported